### PR TITLE
Luxembourg VAT increased to 17 %

### DIFF
--- a/lib/standard-european-vat-rates.js
+++ b/lib/standard-european-vat-rates.js
@@ -19,7 +19,7 @@ var RATES = {
   IE: 23,
   IT: 22,
   LT: 21,
-  LU: 15,
+  LU: 17,
   LV: 21,
   MT: 18,
   NL: 21,


### PR DESCRIPTION
no issue
- VAT was increased to 17 % in Luxembourg
- http://www.vatlive.com/european-news/luxembourg-vat-rise-17-2015/
